### PR TITLE
Fix show method for IntervalCollections

### DIFF
--- a/src/intervals/intervals.jl
+++ b/src/intervals/intervals.jl
@@ -150,7 +150,9 @@ function Base.show(io::IO, is::IntervalCollection)
             end
             println(io, "  ", i)
         end
-        print(io, "  ⋮")
+        if n_entries > max_entries
+            print(io, "  ⋮")
+        end
     end
 end
 

--- a/src/intervals/intervals.jl
+++ b/src/intervals/intervals.jl
@@ -141,14 +141,17 @@ end
 
 function Base.show(io::IO, is::IntervalCollection)
     const max_entries = 8
-    println(io, "IntervalCollection with $(length(is)) intervals:")
-    for (k, i) in enumerate(is)
-        if k > 8
-            break
+    n_entries = length(is)
+    println(io, "IntervalCollection with $(n_entries) intervals:")
+    if n_entries > 0
+        for (k, i) in enumerate(is)
+            if k > 8
+                break
+            end
+            println(io, "  ", i)
         end
-        println(io, "  ", i)
+        print(io, "  ⋮")
     end
-    print(io, "  ⋮")
 end
 
 


### PR DESCRIPTION
- Allow showing an empty IntervalCollection
- Show  ⋮ only if needed, i.e. when the IntervalCollection has more entries than the number to display
